### PR TITLE
fixes to make the iOS app run on iPhone for testing

### DIFF
--- a/Smart_Currency_Converter/Smart_Currency_Converter.Android/Smart_Currency_Converter.Android.csproj
+++ b/Smart_Currency_Converter/Smart_Currency_Converter.Android/Smart_Currency_Converter.Android.csproj
@@ -15,7 +15,6 @@
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
-    <AndroidUseLatestPlatformSdk>false</AndroidUseLatestPlatformSdk>
     <TargetFrameworkVersion>v10.0</TargetFrameworkVersion>
     <AndroidEnableSGenConcurrent>true</AndroidEnableSGenConcurrent>
     <AndroidUseAapt2>true</AndroidUseAapt2>
@@ -100,7 +99,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Smart_Currency_Converter\Smart_Currency_Converter.csproj">
-      <Project>{C28FE658-480E-42F4-B76D-54CE53709551}</Project>
+      <Project>{6B0172D8-D5B5-4CB0-BA57-8F68D63B176B}</Project>
       <Name>Smart_Currency_Converter</Name>
     </ProjectReference>
   </ItemGroup>

--- a/Smart_Currency_Converter/Smart_Currency_Converter.iOS/Info.plist
+++ b/Smart_Currency_Converter/Smart_Currency_Converter.iOS/Info.plist
@@ -23,18 +23,20 @@
 	<key>MinimumOSVersion</key>
 	<string>8.0</string>
 	<key>CFBundleDisplayName</key>
-	<string>Smart_Currency_Converter</string>
+	<string>Smart-Currency-Converter</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.companyname.Smart_Currency_Converter</string>
+	<string>com.test.Smart-Currency-Converter</string>
 	<key>CFBundleVersion</key>
 	<string>1.0</string>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>CFBundleName</key>
-	<string>Smart_Currency_Converter</string>
+	<string>Smart-Currency-Converter</string>
 	<key>XSAppIconAssets</key>
 	<string>Assets.xcassets/AppIcon.appiconset</string>
 	<key>CFBundleShortVersionString</key>
 	<string>Beta</string>
+	<key>NSCameraUsageDescription</key>
+	<string>Camera used for converting currency</string>
 </dict>
 </plist>

--- a/Smart_Currency_Converter/Smart_Currency_Converter.iOS/Smart_Currency_Converter.iOS.csproj
+++ b/Smart_Currency_Converter/Smart_Currency_Converter.iOS/Smart_Currency_Converter.iOS.csproj
@@ -47,7 +47,7 @@
     <MtouchArch>ARM64</MtouchArch>
     <CodesignKey>iPhone Developer</CodesignKey>
     <MtouchDebug>true</MtouchDebug>
-    <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
+<!--    <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>-->
     <MtouchLink>None</MtouchLink>
     <MtouchInterpreter>-all</MtouchInterpreter>
   </PropertyGroup>
@@ -59,7 +59,7 @@
     <WarningLevel>4</WarningLevel>
     <MtouchArch>ARM64</MtouchArch>
     <CodesignKey>iPhone Developer</CodesignKey>
-    <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
+<!--    <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>-->
   </PropertyGroup>
   <PropertyGroup>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>


### PR DESCRIPTION
* Smart_Currency_Converter.Android.csproj:

* Smart_Currency_Converter.iOS.csproj: added NSCameraUsageDescription
  to info.plist. Commented out CodesignEntitlements in .csproj in iOS
  project for local development. Updated Bundle names to include
  hypens so there is a match with the profile generated by XCode.